### PR TITLE
Solve race condition.

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -85,7 +85,7 @@ DWORD MainThread(void*)
 
 						case C_UnloadModule:
 							fl.Log("Unloading ...");
-							FreeLibrary(hThisModule);
+							FreeLibraryAndExitThread(hThisModule, 0);
 							break;
 
 						case C_GetModuleBase:
@@ -130,7 +130,6 @@ BOOL WINAPI DllMain(HINSTANCE hModule, DWORD callReason, LPVOID reserved)
 	{
 		if (hThread)
 		{
-			TerminateThread(hThread, 0);
 			s.ClosePipe();
 			fl.Log("Server module is getting unloaded, cya");
 		}


### PR DESCRIPTION
Directly quote from MSDN:

> The FreeLibraryAndExitThread function allows threads that are executing within a DLL to safely free the DLL in which they are executing and terminate themselves. If they were to call FreeLibrary and ExitThread separately, a race condition would exist. The library could be unloaded before ExitThread is called.

[FreeLibraryAndExitThread function - MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683153(v=vs.85).aspx)